### PR TITLE
fix(readme): Fix example in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ yarn: `yarn add typed-contracts`
 All contracts have this interface:
 
 ```js
-type Contract<T> = {
+type Contract<+T> = {
   (valueName: string): {
     (value: mixed): ValidationError | T,
     optional(value: mixed): ValidationError | void | T,
@@ -71,10 +71,10 @@ const {
 } = require('typed-contracts')
 
 type Person = {
-  name: string,
-  gender: 'm' | 'f',
-  friends: $ReadOnlyArray<Person>,
-  email?: string | $ReadOnlyArray<string>,
+  +name: string,
+  +gender: 'm' | 'f',
+  +friends: $ReadOnlyArray<Person>,
+  +email?: string | $ReadOnlyArray<string>,
 }
 
 // person returns Person-compatible value or ValidationError


### PR DESCRIPTION
After 085ce327767eda6174853119cd700695b9b589a8 commit all inferred object types are read-only, but the object in the example is not for now.

Currently it shows `Cannot assign person(...) to userValidate because property email is read-only in
object type [1] but writable in Person [2] in the return value.` type error.